### PR TITLE
feat: add support for repeater expression

### DIFF
--- a/__tests__/parser.test.js
+++ b/__tests__/parser.test.js
@@ -336,6 +336,14 @@ describe("test for repeater expression", () => {
         }
       }
     `,
+    // array of object
+    `
+      Schemas {
+        User {
+          favColors: []{}
+        }
+      }
+    `,
   ])(
     "given incorrect repeater expression, it should return syntaxError",
     (example) => {
@@ -383,6 +391,30 @@ describe("test for repeater expression", () => {
                       repeater: "array",
                     },
                   },
+                  {
+                    type: "Property",
+                    key: {
+                      type: "IdentifierExpression",
+                      name: "arrayOfObjects",
+                    },
+                    value: {
+                      type: "ObjectExpression",
+                      properties: [
+                        {
+                          type: "Property",
+                          key: {
+                            type: "IdentifierExpression",
+                            name: "something",
+                          },
+                          value: {
+                            type: "IdentifierExpression",
+                            name: "string",
+                          },
+                        },
+                      ],
+                      repeater: "array",
+                    },
+                  },
                 ],
               },
             },
@@ -395,7 +427,10 @@ describe("test for repeater expression", () => {
       Schemas {
         User {
           favColors: string[],
-          arrayOfNumbers: number[]
+          arrayOfNumbers: number[],
+          arrayOfObjects: {
+            something: string,
+          }[]
         }
       }
     `;

--- a/__tests__/parser.test.js
+++ b/__tests__/parser.test.js
@@ -75,7 +75,7 @@ describe("tests for Parameters Block", () => {
             id: string,
             filter: {}
         }
-    }   
+    }
     `;
     const expected = {
       type: "Program",
@@ -112,12 +112,12 @@ describe("tests for Parameters Block", () => {
   it("given Parameters Block with missing opening curly bracket {, should return syntaxError ", () => {
     function parseExample() {
       const example = `
-      Parameters    
+      Parameters
           GetUser {
               id: string,
               filter: {}
           }
-      }   
+      }
       `;
       parser.parse(example);
     }
@@ -225,7 +225,7 @@ describe("tests for RequestBodies Block", () => {
             id: string,
             filter: {}
         }
-    }   
+    }
     `;
     const expected = {
       type: "Program",
@@ -262,12 +262,12 @@ describe("tests for RequestBodies Block", () => {
   it("given RequestBodies Block with missing opening curly bracket {, should return syntaxError ", () => {
     function parseExample() {
       const example = `
-      RequestBodies    
+      RequestBodies
           GetUser {
               id: string,
               filter: {}
           }
-      }   
+      }
       `;
       parser.parse(example);
     }
@@ -317,5 +317,90 @@ describe("tests for RequestBodies Block", () => {
       parser.parse(example);
     }
     expect(parseExample).toThrowError('Expected "{" but "}" found.');
+  });
+});
+
+describe("test for repeater expression", () => {
+  it.each([
+    `
+      Schemas {
+        User {
+          favColors: []string
+        }
+      }
+    `,
+    `
+      Schemas {
+        User {
+          favColors: 12[]
+        }
+      }
+    `,
+  ])(
+    "given incorrect repeater expression, it should return syntaxError",
+    (example) => {
+      function parseExample() {
+        parser.parse(example);
+      }
+      expect(parseExample).toThrowError();
+    }
+  );
+
+  it("given correct repeater expression, should return correct output", () => {
+    const expected = {
+      type: "Program",
+      body: [
+        {
+          type: "SchemasBlockExpression",
+          body: [
+            {
+              type: "SchemaExpression",
+              name: "User",
+              body: {
+                type: "ObjectExpression",
+                properties: [
+                  {
+                    type: "Property",
+                    key: {
+                      type: "IdentifierExpression",
+                      name: "favColors",
+                    },
+                    value: {
+                      type: "IdentifierExpression",
+                      name: "string",
+                      repeater: "array",
+                    },
+                  },
+                  {
+                    type: "Property",
+                    key: {
+                      type: "IdentifierExpression",
+                      name: "arrayOfNumbers",
+                    },
+                    value: {
+                      type: "IdentifierExpression",
+                      name: "number",
+                      repeater: "array",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const example = `
+      Schemas {
+        User {
+          favColors: string[],
+          arrayOfNumbers: number[]
+        }
+      }
+    `;
+
+    expect(() => parser.parse(example)).not.toThrowError();
+    expect(parser.parse(example)).toEqual(expected);
   });
 });

--- a/src/core.pegjs
+++ b/src/core.pegjs
@@ -247,7 +247,7 @@ MemberExpressionList
   }
 
 KeyValueExpression
-	= key:Identifier _ ":" _ value:(ArrayExpression / ObjectExpression / RepeatExpression /CallExpression / Identifier / Literal / Number) {
+	= key:Identifier _ ":" _ value:(ArrayExpression / RepeatExpression / ObjectExpression  /CallExpression / Identifier / Literal / Number) {
     return {
         type: "Property",
         key,
@@ -258,9 +258,9 @@ KeyValueExpression
 // -------- Repeat Expression -----------
 
 RepeatExpression
-  = iden:Identifier "[]" _ {
+  = initialBlock:(ObjectExpression / Identifier) "[]" _ {
     return {
-      ...iden,
+      ...initialBlock,
       repeater: "array"
     }
   }

--- a/src/core.pegjs
+++ b/src/core.pegjs
@@ -247,12 +247,22 @@ MemberExpressionList
   }
 
 KeyValueExpression
-	= key:Identifier _ ":" _ value:(ArrayExpression / ObjectExpression / CallExpression / Identifier / Literal / Number) {
+	= key:Identifier _ ":" _ value:(ArrayExpression / ObjectExpression / RepeatExpression /CallExpression / Identifier / Literal / Number) {
     return {
         type: "Property",
         key,
         value
       }
+  }
+
+// -------- Repeat Expression -----------
+
+RepeatExpression
+  = iden:Identifier "[]" _ {
+    return {
+      ...iden,
+      repeater: "array"
+    }
   }
 
 // -------- Array Expression ---------


### PR DESCRIPTION
### Description

Adding `Repeater Expression` similar to typescript expression. 

```
dataType[];
```

Example:

```
Schemas {
  User {
    arrayOfStrings: string[],
    arrayOfObjects: {
      name: string;
    }[]
  }
}
```

It is more relevant and most programming languages use this.

### Type of change

##### Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
  - support repeater expression
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tests written for repeater expression support

### Screenshot ( applicable for UI changes)

### Checklist:

- [x] Self-review of my own code
- [ ] Commented the code, particularly in hard-to-understand areas
- [ ] Corresponding changes to the documentation
- [x] Ran test on local
- [x] Generated build on local